### PR TITLE
Change Directory color to be visible

### DIFF
--- a/colors/cobalt.vim
+++ b/colors/cobalt.vim
@@ -93,7 +93,7 @@ hi String guifg=#3ad900 guibg=NONE guisp=NONE gui=NONE ctermfg=76 ctermbg=NONE c
 hi PMenuThumb guifg=NONE guibg=#939aa8 guisp=#939aa8 gui=NONE ctermfg=NONE ctermbg=103 cterm=NONE
 hi MatchParen guifg=#ffffff guibg=#d70061 guisp=#d70061 gui=bold ctermfg=15 ctermbg=161 cterm=bold
 hi Repeat guifg=#ff9d00 guibg=NONE guisp=NONE gui=bold ctermfg=214 ctermbg=NONE cterm=bold
-hi Directory guifg=#2c355e guibg=NONE guisp=NONE gui=bold ctermfg=17 ctermbg=NONE cterm=bold
+hi Directory guifg=#2c355e guibg=NONE guisp=NONE gui=bold ctermfg=214 ctermbg=NONE cterm=bold
 hi Structure guifg=#ff9d00 guibg=NONE guisp=NONE gui=bold ctermfg=214 ctermbg=NONE cterm=bold
 hi Macro guifg=#ffdd00 guibg=NONE guisp=NONE gui=NONE ctermfg=220 ctermbg=NONE cterm=NONE
 hi DiffAdd guifg=NONE guibg=#3a3a3a guisp=#3a3a3a gui=NONE ctermfg=NONE ctermbg=237 cterm=NONE


### PR DESCRIPTION
The default `Directory` color makes it very difficult to read directory names with NERDTree. This PR improves that readability.

Before:

<img width="189" alt="screen shot 2017-10-11 at 1 27 16 pm" src="https://user-images.githubusercontent.com/4095660/31465203-129a99da-ae88-11e7-92da-0686b2c80daf.png">

After:

<img width="228" alt="screen shot 2017-10-11 at 1 29 23 pm" src="https://user-images.githubusercontent.com/4095660/31465245-3ac4b71a-ae88-11e7-847c-6f25bb454668.png">
